### PR TITLE
Update model to gpt-5.4 and fix JSON parsing

### DIFF
--- a/ai_shell/ai.py
+++ b/ai_shell/ai.py
@@ -26,13 +26,14 @@ class Ai:
 
     def call(self) -> AiResponse:
         response = self.client.chat.completions.create(
-            model="gpt-4-1106-preview", messages=self.build_messages(), response_format={"type": "json_object"}
+            model="gpt-5.4", messages=self.build_messages(), response_format={"type": "json_object"}
         )
         self.total_tokens += response.usage.total_tokens
         logging.info(f"Tokens: {response.usage.total_tokens}, Total: {self.total_tokens}")
         content = response.choices[0].message.content
         logging.debug("Response content: " + content)
-        return AiResponse.model_validate_json(content)
+        data, _ = json.JSONDecoder().raw_decode(content.strip())
+        return AiResponse.model_validate(data)
 
     def build_messages(self):
         messages = [


### PR DESCRIPTION
## Summary

- Replace deprecated `gpt-4-1106-preview` with `gpt-5.4`
- Switch from `model_validate_json()` to `json.JSONDecoder().raw_decode()` + `model_validate()` to handle trailing content that `gpt-5.4` appends after the JSON object

## Test plan

- [ ] All 3 tests pass (`pytest test_aishell.py -v`) with `OPENAI_API_KEY` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)